### PR TITLE
Remove view registration from package configuration

### DIFF
--- a/src/FilamentNotificationSoundServiceProvider.php
+++ b/src/FilamentNotificationSoundServiceProvider.php
@@ -16,8 +16,7 @@ class FilamentNotificationSoundServiceProvider extends PackageServiceProvider
     {
         $package
             ->name(static::$name)
-            ->hasConfigFile()
-            ->hasViews();
+            ->hasConfigFile();
     }
 
     public function packageBooted(): void


### PR DESCRIPTION
We don't need to register that there are views because we don't have any, and this is causing an error in the `php artisan view:cache` function.